### PR TITLE
Add SyncLocalStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,21 @@ src
 │   ├── HomeTitle
 │   ├── NewsList
 │   ├── SelectWeekDay
+│   ├── SyncLocalStorage
 │   └── TodoListView
 ├── pages
+│   ├── _app.tsx
+│   ├── _document.tsx
 │   ├── add-todo
 │   ├── api
+│   ├── index.tsx
 │   └── update-todo
 ├── stores
+│   ├── atoms.ts
+│   ├── memoryLocalStorage.ts
+│   ├── selectors.ts
+│   └── types.ts
 └── styles
+    └── globals.css
+
 ```

--- a/src/components/SyncLocalStorage/index.tsx
+++ b/src/components/SyncLocalStorage/index.tsx
@@ -1,0 +1,23 @@
+import React, { ReactNode, useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
+
+import { todoListState } from '@/stores/atoms';
+import memoryLocalStorage from '@/stores/memoryLocalStorage';
+
+type SyncLocalStorageProps = {
+  children: ReactNode;
+};
+
+export default function SyncLocalStorage({ children }: SyncLocalStorageProps) {
+  const setTodoList = useSetRecoilState(todoListState);
+
+  useEffect(() => {
+    memoryLocalStorage.setWindow();
+    memoryLocalStorage.sync('todolist');
+    if (memoryLocalStorage.hasItem('todolist')) {
+      setTodoList(() => [...JSON.parse(memoryLocalStorage.getItem('todolist') as string)]);
+    }
+  }, [setTodoList]);
+
+  return <>{children}</>;
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,12 +1,16 @@
 import '@/styles/globals.css';
-import type { AppProps } from 'next/app';
 
 import { RecoilRoot } from 'recoil';
+import type { AppProps } from 'next/app';
+
+import SyncLocalStorage from '@/components/SyncLocalStorage';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <RecoilRoot>
-      <Component {...pageProps} />
+      <SyncLocalStorage>
+        <Component {...pageProps} />
+      </SyncLocalStorage>
     </RecoilRoot>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,14 +1,10 @@
 import Head from 'next/head';
-import React, { useEffect } from 'react';
-import { useSetRecoilState } from 'recoil';
 
 import Container from '@/components/Container';
 import HomeTitle from '@/components/HomeTitle';
 import NewsList from '@/components/NewsList';
 import { NewsItem } from '@/components/NewsList/types';
 import TodoListView from '@/components/TodoListView';
-import { todoListState } from '@/stores/atoms';
-import memoryLocalStorage from '@/stores/memoryLocalStorage';
 
 import jsonData from './api/data.json';
 
@@ -20,17 +16,6 @@ type HomeProps = {
 };
 
 export default function Home({ newsData }: HomeProps) {
-  const setTodoList = useSetRecoilState(todoListState);
-
-  useEffect(() => {
-    memoryLocalStorage.setWindow();
-    memoryLocalStorage.sync('todolist');
-    const one = memoryLocalStorage.getItem('todolist');
-    if (one) {
-      setTodoList(() => [...JSON.parse(one)]);
-    }
-  }, [setTodoList]);
-
   return (
     <>
       <Head>
@@ -48,7 +33,6 @@ export default function Home({ newsData }: HomeProps) {
 }
 
 export async function getServerSideProps() {
-  // NOTE:
   const newsData = await getNewsData({ page: 1, count: 10 });
   return { props: { newsData: newsData } };
 }

--- a/src/pages/update-todo/[id].tsx
+++ b/src/pages/update-todo/[id].tsx
@@ -7,7 +7,6 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import Container from '@/components/Container';
 import SelectWeekDay from '@/components/SelectWeekDay';
 import { todoListState } from '@/stores/atoms';
-import memoryLocalStorage from '@/stores/memoryLocalStorage';
 import { selectTodoItemById } from '@/stores/selectors';
 import { RepeatedDay } from '@/stores/types';
 
@@ -51,16 +50,8 @@ export default function UpdateTodo() {
   });
 
   useEffect(() => {
-    memoryLocalStorage.setWindow();
-    memoryLocalStorage.sync('todolist');
-    const one = memoryLocalStorage.getItem('todolist');
-
-    if (one && !todoItem) {
-      setTodoList(() => [...JSON.parse(one)]);
-    }
     if (todoItem) {
-      const defaultValue = { title: todoItem?.title, content: todoItem?.content };
-      reset(defaultValue);
+      reset({ title: todoItem?.title, content: todoItem?.content });
       setRepeatedDayList(repeatedDayList.map((_, idx) => todoItem.repeatedDay.includes(idx)));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/stores/atoms.ts
+++ b/src/stores/atoms.ts
@@ -5,9 +5,8 @@ import { Todo } from './types';
 
 const initData: Todo[] = [];
 
-let id = initData.length;
 export function getTodoId() {
-  return ++id;
+  return memoryLocalStorage.getItemCount('todolist');
 }
 
 // NOTE(@brightchul): Recoil을 next.js 사용시 hot module replacement로 인해 동일 키 생성되는 문제 우회

--- a/src/stores/memoryLocalStorage.ts
+++ b/src/stores/memoryLocalStorage.ts
@@ -6,6 +6,7 @@ class MemoryLocalStorage {
     this.window = undefined;
     this.data = Object.create(null);
   }
+
   setWindow() {
     if (typeof window === 'undefined') {
       return;
@@ -13,32 +14,44 @@ class MemoryLocalStorage {
     this.window = window;
   }
   sync(key: string) {
-    if (this.window === undefined) {
+    if (!this.checkMemoryWindow()) {
       return;
     }
-    const jsonData = localStorage.getItem(key);
 
+    const jsonData = localStorage.getItem(key);
     if (typeof jsonData !== 'string') return;
     const data = JSON.parse(jsonData);
     Object.keys(data).forEach((key) => (this.data[key] = data[key]));
   }
 
+  checkMemoryWindow() {
+    return this.window !== undefined;
+  }
+
+  hasItem(key: string) {
+    if (!this.checkMemoryWindow()) {
+      return false;
+    }
+    const item = this.getItem(key);
+    return !!item;
+  }
+
   setItem(key: string, item: string) {
-    if (this.window !== undefined) {
+    if (this.checkMemoryWindow()) {
       localStorage.setItem(key, item);
     }
     this.data[key] = item;
   }
 
   getItem(key: string) {
-    if (this.window !== undefined) {
+    if (this.checkMemoryWindow()) {
       return localStorage.getItem(key);
     }
     return this.data[key] ?? null;
   }
 
   removeItem(key: string) {
-    if (this.window !== undefined) {
+    if (this.checkMemoryWindow()) {
       localStorage.removeItem(key);
     }
     delete this.data[key];

--- a/src/stores/memoryLocalStorage.ts
+++ b/src/stores/memoryLocalStorage.ts
@@ -56,6 +56,14 @@ class MemoryLocalStorage {
     }
     delete this.data[key];
   }
+
+  getItemCount(key: string) {
+    if (!this.hasItem(key)) {
+      return 0;
+    }
+    const objectList = JSON.parse(this.getItem(key) as string) ?? [];
+    return objectList.length;
+  }
 }
 
 const memoryLocalStorage = new MemoryLocalStorage();


### PR DESCRIPTION
## Summary
- SyncLocalStorage 를 추가하여 localstorage를 동기화 하는 로직을 분리
- getTodoId의 Id 증가 로직 수정

## Detail

### SyncLocalStorage 를 추가하여 localstorage를 동기화 하는 로직을 분리
- 기존에는 각 페이지에서 새로고침 이후 마운트 되었을 때 useEffect 를 이용해서 직접 localstorage 데이터를 동기화
- 이부분을 분리하여 _app.tsx로 이동 시켜서 작업을 진행하고 개별 페이지에서는 해당 로직을 제거

### getTodoId의 Id 증가 로직 수정
- 기존에는 getTodoId의 id 값은 해당 모듈 스코프의 클로저 값을 증가 시켜서 사용
- 이렇게 할 경우 localstorage의 아이템 개수와는 동기화가 제대로 진행되지 않아서 잘못된 아이디 값을 사용하는 문제 발생
- 해당 부분을 memoryLocalStorage에서 localstorage의 아이템 개수를 반환하는 식으로 처리해서 수정
