### PR TITLE
Fix to  generate new todo id logic

### DIFF
--- a/src/pages/add-todo/index.tsx
+++ b/src/pages/add-todo/index.tsx
@@ -3,11 +3,12 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import Container from '@/components/Container';
 import SelectWeekDay from '@/components/SelectWeekDay';
-import { getTodoId, todoListState } from '@/stores/atoms';
+import { todoListState } from '@/stores/atoms';
+import { getTodoItemLastId } from '@/stores/selectors';
 import { RepeatedDay } from '@/stores/types';
 
 export default function AddTodo() {
@@ -18,6 +19,8 @@ export default function AddTodo() {
   const { register, handleSubmit, formState } = useForm({ defaultValues: { title: '', content: '' } });
 
   const [repeatedDayList, setRepeatedDayList] = useState([false, false, false, false, false, false, false]);
+
+  const newId = useRecoilValue(getTodoItemLastId) + 1;
 
   const addTodo = ({ title, content }: { title: string; content: string }) => {
     const repeatedDay: RepeatedDay[] = repeatedDayList
@@ -32,7 +35,7 @@ export default function AddTodo() {
         createdAt: dayjs().toString(),
         repeatedDay,
         isComplete: false,
-        id: getTodoId(),
+        id: newId,
       },
     ]);
     router.push('/');

--- a/src/stores/atoms.ts
+++ b/src/stores/atoms.ts
@@ -5,10 +5,6 @@ import { Todo } from './types';
 
 const initData: Todo[] = [];
 
-export function getTodoId() {
-  return memoryLocalStorage.getItemCount('todolist');
-}
-
 // NOTE(@brightchul): Recoil을 next.js 사용시 hot module replacement로 인해 동일 키 생성되는 문제 우회
 export const todoListState = atom<Todo[]>({
   key: `todoListState/${Date.now()}`,

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -30,3 +30,11 @@ export const selectTodoItemById = selectorFamily({
       return entireTodoList.find(({ id }) => id === todoId);
     },
 });
+
+export const getTodoItemLastId = selector({
+  key: 'getTodoItemLastId',
+  get: ({ get }) => {
+    const entireTodoList = get(todoListState);
+    return entireTodoList.reduce((newId, todoItem) => Math.max(newId, todoItem.id), 0);
+  },
+});


### PR DESCRIPTION
## Summary
- getTodoItemLastId 셀렉터를 추가하여 newId 생성 로직을 수정했다. 

## Detail
- 기존의 방식에서는 localstorate 안의 개수를 가지고 생성했다.
- 이 방식의 문제는 총 갯수 기준이기 때문에 동일 id 생성 문제가 있었다.
- memoryLocalStorage 에서 직접 요청하기 때문에 내부 도메인 상태가 아니라 특정 객체에 의존성도 존재했다.
- 이것을 내부 도메인 상태에서 마지막 id값을 가져와서 하도록 selector를 추가했다.