### PR TITLE
Fix to remove duplicate atom key warning

### DIFF
--- a/src/stores/atoms.ts
+++ b/src/stores/atoms.ts
@@ -2,12 +2,13 @@ import { atom } from 'recoil';
 
 import memoryLocalStorage from './memoryLocalStorage';
 import { Todo } from './types';
+import { atomKey } from './util';
 
 const initData: Todo[] = [];
 
 // NOTE(@brightchul): Recoil을 next.js 사용시 hot module replacement로 인해 동일 키 생성되는 문제 우회
 export const todoListState = atom<Todo[]>({
-  key: `todoListState/${Date.now()}`,
+  key: atomKey('todoListState'),
   default: initData,
   effects: [
     ({ setSelf, onSet }) => {

--- a/src/stores/selectors.ts
+++ b/src/stores/selectors.ts
@@ -4,9 +4,10 @@ import { selector, selectorFamily } from 'recoil';
 
 import { todoListState } from './atoms';
 import { Todo } from './types';
+import { atomKey } from './util';
 
 export const todayTodoListState = selector({
-  key: 'todayTodoListState',
+  key: atomKey('todayTodoListState'),
   get: ({ get }) => {
     dayjs.extend(isToday);
     const dayNumber = dayjs().day();
@@ -22,7 +23,7 @@ export const todayTodoListState = selector({
 });
 
 export const selectTodoItemById = selectorFamily({
-  key: 'todoItemByIdState',
+  key: atomKey('todoItemByIdState'),
   get:
     (todoId: number) =>
     ({ get }) => {
@@ -32,7 +33,7 @@ export const selectTodoItemById = selectorFamily({
 });
 
 export const getTodoItemLastId = selector({
-  key: 'getTodoItemLastId',
+  key: atomKey('getTodoItemLastId'),
   get: ({ get }) => {
     const entireTodoList = get(todoListState);
     return entireTodoList.reduce((newId, todoItem) => Math.max(newId, todoItem.id), 0);

--- a/src/stores/util.ts
+++ b/src/stores/util.ts
@@ -1,0 +1,1 @@
+export const atomKey = (name: string) => `${name}-${Date.now()}`;


### PR DESCRIPTION
## Summary
- 핫리로드 과정에서 일어나는  atom key 중복 경고를 제거 했다. 


## Detail
```
Expectation Violation: Duplicate atom key "getTodoItemLastId". This is a FATAL ERROR in
      production. But it is safe to ignore this warning if it occurred because of
      hot module replacement.
```
- HMR 에서 동일 atom key가 나타나서 next.js와 recoil을 사용하게 되면 위와 같은 경고 메세지가 개발중에 나타난다.
- 프로덕션에서는 HMR 모드로 실행되지 않기 때문에 큰 문제는 아니지만 그래도 불필요한 경고를 제거했다.
- atomKey 함수를 추가하여 `${name}-${Date.now()}` 로 각 atomKey를 생성하도록 수정했다. 